### PR TITLE
Feature/add 32 bit and no dll copying

### DIFF
--- a/game_bridge_installer/GameBridgeInstaller/GUIHandler.cs
+++ b/game_bridge_installer/GameBridgeInstaller/GUIHandler.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Win32;
-using System;
 using System.Diagnostics;
-using System.IO;
 using System.Text.RegularExpressions;
 
 namespace GameBridgeInstaller

--- a/game_bridge_installer/GameBridgeInstaller/GUIHandler.cs
+++ b/game_bridge_installer/GameBridgeInstaller/GUIHandler.cs
@@ -1,5 +1,8 @@
 ﻿using Microsoft.Win32;
+using System;
 using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
 
 namespace GameBridgeInstaller
 {
@@ -114,11 +117,26 @@ namespace GameBridgeInstaller
             // First, copy all required SR files to the target path.
             try
             {
-                foreach (string dllName in SRDlls)
+                // Check the name of the addon with a regex to see if SR DLLs need to be copied or not.
+                bool copySrDlls = false;
+                string fileName = SRAddonPath.Substring(SRAddonPath.LastIndexOf('\\') + 1);
+                string pattern = @"(\d+\.\d+\.\d+)";
+                // Get the version number of the addon from the addon name and check if it's a version where we still need to copy addons.
+                MatchCollection matches = Regex.Matches(fileName, pattern);
+                string matchedString = matches[matches.Count - 1].Value;
+                string matchedSplitString = matchedString.Replace(".", "");
+                if (int.Parse(matchedSplitString) <= 030)
                 {
-                    File.Copy(SRInstallpath + "\\bin\\" + dllName, pathToGameExe.Substring(0, pathToGameExe.Length - gameExeName.Length) + "\\" + dllName, true);
+                    copySrDlls = true;
                 }
 
+                if (copySrDlls)
+                {
+                    foreach (string dllName in SRDlls)
+                    {
+                        File.Copy(SRInstallpath + "\\bin\\" + dllName, pathToGameExe.Substring(0, pathToGameExe.Length - gameExeName.Length) + "\\" + dllName, true);
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/game_bridge_installer/GameBridgeInstaller/GUIHandler.cs
+++ b/game_bridge_installer/GameBridgeInstaller/GUIHandler.cs
@@ -616,35 +616,6 @@ namespace GameBridgeInstaller
             }
         }
 
-        // Checks if a file at a given path is 32 or 64-bit.
-        //static bool Is64BitExecutableUsingWinAPI(string filePath)
-        //{
-        //    // Open the file using the Windows API
-        //    using (var stream = new System.IO.FileStream(filePath, System.IO.FileMode.Open, System.IO.FileAccess.Read))
-        //    using (var reader = new System.IO.BinaryReader(stream))
-        //    {
-        //        // Check the PE header offset
-        //        stream.Position = 0x3C;
-        //        int peOffset = reader.ReadInt32();
-
-        //        // Move to the PE header
-        //        stream.Position = peOffset;
-
-        //        // Check for "PE\0\0" signature
-        //        if (reader.ReadUInt32() != 0x00004550)
-        //            throw new BadImageFormatException("Not a valid PE file");
-
-        //        // Skip 4 bytes (machine type is right after)
-        //        stream.Position += 4;
-
-        //        // Read the machine type
-        //        ushort machine = reader.ReadUInt16();
-
-        //        // Check if the machine type indicates 64-bit
-        //        return machine == 0x8664 || machine == 0x0200; // AMD64 or IA64
-        //    }
-        //}
-
         enum PlatformFile : uint
         {
             Unknown = 0,

--- a/game_bridge_installer/GameBridgeInstaller/Main.cs
+++ b/game_bridge_installer/GameBridgeInstaller/Main.cs
@@ -122,7 +122,7 @@ namespace GameBridgeInstaller
             if (!handler.CheckIfSRInstallIsValid(handler.GetSRInstallPathFromRegistry()))
             {
                 // SR Install invalid
-                MessageBox.Show("Couldn't find Simulated Reality install. Please (re)install the SR Platform:\n(https://www.srappstore.com/)", "SR install not found", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show("Couldn't find Simulated Reality install. Please (re)install the SR Platform:\n(https://github.com/LeiaInc/leiainc.github.io/tree/master/SRSDK)", "SR install not found", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 enableButtons();
                 return false;
             }

--- a/game_bridge_installer/GameBridgeInstaller/readme.md
+++ b/game_bridge_installer/GameBridgeInstaller/readme.md
@@ -59,7 +59,7 @@ The ReShade installer must be formatted as follows:<br/>
 A srReshade.addon file must be present alongside the "GameBridgeInstaller.exe" file.
 
 The ReShade installer must be formatted as follows:<br/>
-**srReshade\*.addon**
+**srReshade\*{versionNr}\*.addon**
 
 **Note:** Make sure that the version of the srReshade.addon you are installing is compatible with the installed version of the SR Platform. A quick compatibility list is shown below:
 * SR Platform version < = 1.27.4 is compatible with:


### PR DESCRIPTION
Added support for checking 32-bit DLLs and making sure that DDLs are not copied when the addon version is above 0.3.0.