### PR TITLE
Parse EXE's That Contain Multiple Periods

### DIFF
--- a/game_bridge_installer/GameBridgeInstaller/GUIHandler.cs
+++ b/game_bridge_installer/GameBridgeInstaller/GUIHandler.cs
@@ -193,10 +193,11 @@ namespace GameBridgeInstaller
             // Reset global variables
             ResetGlobals();
 
-            // Split exe name off from path.
+            // Get the complete EXE string
             gameExeName = pathToGameExe.Substring(pathToGameExe.LastIndexOf("\\"), pathToGameExe.Length - pathToGameExe.LastIndexOf("\\"));
-            // Cut the '.exe' part off the gameExeName.
-            gameExeNameWithoutExtension = gameExeName.Split('.')[0];
+            // Get the name without .EXE appended
+            gameExeNameWithoutExtension = fetchRootGameName();
+
             // Cut the '.exe' part off the pathToGameExe. Pushed 1 index back to include the '\\' characters.
             gameExeFolderPath = pathToGameExe.Substring(0, pathToGameExe.LastIndexOf("\\") + 1);
 
@@ -277,7 +278,7 @@ namespace GameBridgeInstaller
                 // Todo: Get the return code from the ReShade installer in case it fails.
                 string cmdArguments = "--headless --elevated --api " + reshadeGraphicsApiArgument + " \"" + pathToGameExe + "\"";
                 Process process = Process.Start(ReshadeInstallerPath, cmdArguments);
-                if(!process.WaitForExit(10000))
+                if (!process.WaitForExit(10000))
                 {
                     return "The Reshade installer has timed out.";
                 }
@@ -348,7 +349,8 @@ namespace GameBridgeInstaller
 
                     return "An exception occured while copying the SuperDepth3D fix:\n\n" + ex.Message;
                 }
-            } else if (!superDepth3DFixFound && !geo11FixFound)
+            }
+            else if (!superDepth3DFixFound && !geo11FixFound)
             {
                 // Copy the SuperDepth3D/Reshade configs
                 try
@@ -374,10 +376,10 @@ namespace GameBridgeInstaller
             // Reset global variables
             ResetGlobals();
 
-            // Split exe name off from path.
+            // Get the complete EXE string
             gameExeName = pathToGameExe.Substring(pathToGameExe.LastIndexOf("\\"), pathToGameExe.Length - pathToGameExe.LastIndexOf("\\"));
-            // Cut the '.exe' part off the gameExeName.
-            gameExeNameWithoutExtension = gameExeName.Split('.')[0];
+            // Get the name without .EXE appended
+            gameExeNameWithoutExtension = fetchRootGameName();
             // Cut the '.exe' part off the pathToGameExe. Pushed 1 index back to include the '\\' characters.
             gameExeFolderPath = pathToGameExe.Substring(0, pathToGameExe.LastIndexOf("\\") + 1);
 
@@ -540,6 +542,22 @@ namespace GameBridgeInstaller
 
             return "";
         }
+        
+        /// <summary>
+        /// Fetches the name of the game, including special cases where the game name contains a period, before  ".EXE"
+        /// </summary>
+        /// <returns>The sanitized EXE name, without ".exe" appended</returns>
+        private string fetchRootGameName()
+        {
+            string result;
+
+            string[] tempExeNameArr = gameExeName.Split('.');
+            // if true, that means we have more than one period in the filename so we should grab everything but the last index and combine it
+            // otherwise, return the first index as normal
+            result = tempExeNameArr.Length > 1 ? String.Join('.', tempExeNameArr.Take(tempExeNameArr.Length - 1)) : tempExeNameArr[0];
+
+            return result;
+        }
 
         public string OpenWindowsExplorerDialog()
         {
@@ -553,7 +571,7 @@ namespace GameBridgeInstaller
             {
                 // Get the path of specified file
                 return fd.FileName;
-            } 
+            }
             else
             {
                 return "";


### PR DESCRIPTION
Some games contain multiple periods in their filenames.  For example, the remake/remaster of Nier Replicant formally has the name:

`NieR Replicant ver.1.22474487139.exe`

for its executable.  The parsing logic for getting the name of the EXE would lob off at the first (going left to right) instance of a period.  So, using the same EXE name again, the folder containing the fix would need to be declared as:

`NieR Replicant ver`

for the EXE to be picked up properly.

This fix will simply check to see if the initial `split` of the file name has multiple indexes, and if so, grabs everything before the last (since the last _should always_ be `exe`).  Testing locally:

<img width="2642" height="217" alt="image" src="https://github.com/user-attachments/assets/ab42754a-6fef-484d-9f91-888845d7d27b" />

The entire string of `NieR Replicant ver.1.22474487139` is preserved.

For comparison, this what the original logic would return in this spot:

<img width="2616" height="249" alt="image" src="https://github.com/user-attachments/assets/54b1fd59-0c2c-4368-9f67-aba8b001be2b" />

(install/uninstall have the same initial setup before the get going.  I'm running the uninstall steps in both cases).

---

Tested on Windows 10 22H2
Built/debugged using VSCode with the official Microsoft Extensions.

Addresses https://github.com/BramTeurlings/3DGameBridgeGUI/issues/6